### PR TITLE
Prepended encrypted method in cipher/noop #367

### DIFF
--- a/crypto/cipher/noop/decrypter_test.go
+++ b/crypto/cipher/noop/decrypter_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/mailchain/mailchain/crypto/cipher"
+	"github.com/pkg/errors"
 )
 
 func TestNewDecrypter(t *testing.T) {
@@ -49,16 +50,28 @@ func TestDecrypter_Decrypt(t *testing.T) {
 		d       Decrypter
 		args    args
 		want    cipher.PlainContent
+		err     error
 		wantErr bool
 	}{
 		{
 			"success",
 			NewDecrypter(),
 			args{
-				cipher.EncryptedContent([]byte("test content")),
+				bytesEncode(cipher.EncryptedContent([]byte("test content"))),
 			},
 			cipher.PlainContent([]byte("test content")),
+			nil,
 			false,
+		},
+		{
+			"fail,invalid prefix",
+			NewDecrypter(),
+			args{
+				cipher.EncryptedContent([]byte("test content")),
+			},
+			nil,
+			errors.Errorf("invalid prefix"),
+			true,
 		},
 	}
 	for _, tt := range tests {
@@ -68,6 +81,8 @@ func TestDecrypter_Decrypt(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Decrypter.Decrypt() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			} else if err != nil && err.Error() != tt.err.Error() {
+				t.Errorf("Decrypter.Decrypt() error = %v, want %v", err, tt.err)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Decrypter.Decrypt() = %v, want %v", got, tt.want)

--- a/crypto/cipher/noop/encoding.go
+++ b/crypto/cipher/noop/encoding.go
@@ -16,19 +16,23 @@ package noop
 
 import (
 	"github.com/mailchain/mailchain/crypto/cipher"
+	"github.com/pkg/errors"
 )
 
-// NewDecrypter create a new decrypter attaching the private key to it
-func NewDecrypter() Decrypter {
-	return Decrypter{}
+// bytesEncode encode the encrypted data to the hex format
+func bytesEncode(data cipher.EncryptedContent) cipher.EncryptedContent {
+	encodedData := make(cipher.EncryptedContent, 1+len(data))
+	encodedData[0] = cipher.NoOperation
+	copy(encodedData[1:], data)
+
+	return encodedData
 }
 
-// Decrypter will decrypt data using AES256CBC method
-type Decrypter struct {
-}
+// bytesDecode convert the hex format in to the encrypted data format
+func bytesDecode(raw cipher.EncryptedContent) (cipher.EncryptedContent, error) {
+	if raw[0] != cipher.NoOperation {
+		return nil, errors.Errorf("invalid prefix")
+	}
 
-// Decrypt data using recipient private key with AES in CBC mode.
-func (d Decrypter) Decrypt(data cipher.EncryptedContent) (cipher.PlainContent, error) {
-	content, err := bytesDecode(data)
-	return cipher.PlainContent(content), err
+	return raw[1:], nil
 }

--- a/crypto/cipher/noop/encrypter.go
+++ b/crypto/cipher/noop/encrypter.go
@@ -22,5 +22,5 @@ type Encrypter struct {
 // PlainContent will be return as EncryptedContent with the encryption method
 // prepend as the first byte.
 func (e Encrypter) Encrypt(recipientPublicKey crypto.PublicKey, message cipher.PlainContent) (cipher.EncryptedContent, error) {
-	return cipher.EncryptedContent(message), nil
+	return bytesEncode(cipher.EncryptedContent(message)), nil
 }

--- a/crypto/cipher/noop/encrypter_test.go
+++ b/crypto/cipher/noop/encrypter_test.go
@@ -46,7 +46,7 @@ func TestEncrypter_Encrypt(t *testing.T) {
 				nil,
 				cipher.PlainContent([]byte("test content")),
 			},
-			cipher.EncryptedContent([]byte("test content")),
+			bytesEncode(cipher.EncryptedContent([]byte("test content"))),
 			false,
 		},
 	}


### PR DESCRIPTION
Fixes #367 

Prefix `NoOperation` was prepended data of `cipher/noop` 