### PR TITLE
feat: include encryption types with public key

### DIFF
--- a/cmd/mailchain/internal/http/handlers/pubkey.go
+++ b/cmd/mailchain/internal/http/handlers/pubkey.go
@@ -72,10 +72,17 @@ func GetPublicKey(finders map[string]mailbox.PubKeyFinder) func(w http.ResponseW
 			return
 		}
 
+		encryptionTypes, err := pubkey.EncryptionMethods(publicKey.Kind())
+		if err != nil {
+			errs.JSONWriter(w, http.StatusInternalServerError, errors.WithStack(err))
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(GetPublicKeyResponseBody{
 			PublicKey:         encodedKey,
 			PublicKeyEncoding: encodingType,
+			SupportedEncryptionTypes: encryptionTypes,
 		})
 	}
 }
@@ -160,4 +167,10 @@ type GetPublicKeyResponseBody struct {
 	// Required: true
 	// example: hex/0x-prefix
 	PublicKeyEncoding string `json:"public_key_encoding"`
+
+	// Supported encryption methods for public keys.
+	//
+	// Required: true
+	// example: ["aes256cbc", "nacl", "noop"]
+	SupportedEncryptionTypes []string `json:"supported_encryption_types"`
 }

--- a/cmd/mailchain/internal/http/handlers/pubkey_test.go
+++ b/cmd/mailchain/internal/http/handlers/pubkey_test.go
@@ -225,7 +225,7 @@ func TestGetPublicKey(t *testing.T) {
 				"network":  "mainnet",
 				"protocol": "ethereum",
 			},
-			"{\"public_key\":\"0x69d908510e355beb1d5bf2df8129e5b6401e1969891e8016a0b2300739bbb00687055e5924a2fd8dd35f069dc14d8147aa11c1f7e2f271573487e1beeb2be9d0\",\"public_key_encoding\":\"hex/0x-prefix\"}\n",
+			"{\"public_key\":\"0x69d908510e355beb1d5bf2df8129e5b6401e1969891e8016a0b2300739bbb00687055e5924a2fd8dd35f069dc14d8147aa11c1f7e2f271573487e1beeb2be9d0\",\"public_key_encoding\":\"hex/0x-prefix\",\"supported_encryption_types\":[\"aes256cbc\",\"noop\"]}\n",
 			http.StatusOK,
 		},
 		{
@@ -242,7 +242,7 @@ func TestGetPublicKey(t *testing.T) {
 				"network":  "mainnet",
 				"protocol": "ethereum",
 			},
-			"{\"public_key\":\"0xbdf6fb97c97c126b492186a4d5b28f34f0671a5aacc974da3bde0be93e45a1c50f89ceff72bd04ac9e25a04a1a6cb010aedaf65f91cec8ebe75901c49b63355d\",\"public_key_encoding\":\"hex/0x-prefix\"}\n",
+			"{\"public_key\":\"0xbdf6fb97c97c126b492186a4d5b28f34f0671a5aacc974da3bde0be93e45a1c50f89ceff72bd04ac9e25a04a1a6cb010aedaf65f91cec8ebe75901c49b63355d\",\"public_key_encoding\":\"hex/0x-prefix\",\"supported_encryption_types\":[\"aes256cbc\",\"noop\"]}\n",
 			http.StatusOK,
 		},
 	}

--- a/crypto/cipher/encrypter/encrypter.go
+++ b/crypto/cipher/encrypter/encrypter.go
@@ -10,9 +10,12 @@ import (
 
 // Cipher Name lookup
 const (
+	// NoOperation encryption type name.
 	NoOperation string = "noop"
-	NACL        string = "nacl"
-	AES256CBC   string = "aes256cbc"
+	// NACL encryption type name.
+	NACL string = "nacl"
+	// AES256CBC encryption type name.
+	AES256CBC string = "aes256cbc"
 )
 
 // GetEncrypter is an `Encrypter` factory that returns an encrypter

--- a/internal/pubkey/encryption_types.go
+++ b/internal/pubkey/encryption_types.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Finobo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubkey
+
+import (
+	"fmt"
+
+	"github.com/mailchain/mailchain/crypto"
+	"github.com/mailchain/mailchain/crypto/cipher/encrypter"
+)
+
+// EncryptionMethods returns supported encryption methods.
+func EncryptionMethods(kind string) ([]string, error) {
+	switch kind {
+	case crypto.ED25519:
+		return []string{encrypter.NACL, encrypter.NoOperation}, nil
+	case crypto.SECP256K1:
+		return []string{encrypter.AES256CBC, encrypter.NoOperation}, nil
+	default:
+		return nil, fmt.Errorf("%q unsuported public key type", kind)
+	}
+}

--- a/internal/pubkey/encryption_types_test.go
+++ b/internal/pubkey/encryption_types_test.go
@@ -1,0 +1,74 @@
+// Copyright 2019 Finobo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubkey
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/mailchain/mailchain/crypto"
+	"github.com/mailchain/mailchain/crypto/cipher/encrypter"
+)
+
+func TestEncryptionMethods(t *testing.T) {
+	type args struct {
+		kind string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			"ed25519",
+			args{
+				crypto.ED25519,
+			},
+			[]string{encrypter.NACL, encrypter.NoOperation},
+			false,
+		},
+		{
+			"secp256k1",
+			args{
+				crypto.SECP256K1,
+			},
+			[]string{encrypter.AES256CBC, encrypter.NoOperation},
+			false,
+		},
+		{
+			"unknown",
+			args{
+				"unknown",
+			},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EncryptionMethods(tt.args.kind)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EncryptionMethods() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("EncryptionMethods() gotTypes = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
return a list of available encryption methods with the public key as described in #312 