### PR TITLE
 refactor: Rename DecodeZeroX and EncodeZeroX to include hex #429

### DIFF
--- a/internal/address/decode.go
+++ b/internal/address/decode.go
@@ -25,7 +25,7 @@ import (
 func DecodeByProtocol(in, protocol string) ([]byte, error) {
 	switch protocol {
 	case protocols.Ethereum:
-		return encoding.DecodeZeroX(in)
+		return encoding.DecodeHexZeroX(in)
 	case protocols.Substrate:
 		return base58.Decode(in)
 	default:

--- a/internal/address/encode.go
+++ b/internal/address/encode.go
@@ -25,7 +25,7 @@ func EncodeByProtocol(in []byte, protocol string) (encoded, encodingType string,
 	switch protocol {
 	case protocols.Ethereum:
 		encodingType = encoding.TypeHex0XPrefix
-		encoded = encoding.EncodeZeroX(in)
+		encoded = encoding.EncodeHexZeroX(in)
 	default:
 		err = errors.Errorf("%q unsupported protocol", protocol)
 	}

--- a/internal/encoding/encodingtest/zerox.go
+++ b/internal/encoding/encodingtest/zerox.go
@@ -16,9 +16,9 @@ package encodingtest
 
 import "github.com/mailchain/mailchain/internal/encoding"
 
-// MustDecodeZeroX decodes a hex string. It panics for invalid input.
-func MustDecodeZeroX(in string) []byte {
-	dec, err := encoding.DecodeZeroX(in)
+// MustDecodeHexZeroX decodes a hex string. It panics for invalid input.
+func MustDecodeHexZeroX(in string) []byte {
+	dec, err := encoding.DecodeHexZeroX(in)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/encoding/hex.go
+++ b/internal/encoding/hex.go
@@ -21,10 +21,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EncodeZeroX encodes src into "0x"+hex.Encode. As a convenience, it returns the encoding type used,
+// EncodeHexZeroX encodes src into "0x"+hex.Encode. As a convenience, it returns the encoding type used,
 // but this value is always TypeHex0XPrefix.
-// EncodeZeroX uses hexadecimal encoding prefixed with "0x".
-func EncodeZeroX(src []byte) (encoded string) {
+// EncodeHexZeroX uses hexadecimal encoding prefixed with "0x".
+func EncodeHexZeroX(src []byte) (encoded string) {
 	out := make([]byte, len(src)*2+2)
 	copy(out, "0x")
 	hex.Encode(out[2:], src)
@@ -32,11 +32,11 @@ func EncodeZeroX(src []byte) (encoded string) {
 	return string(out)
 }
 
-// DecodeZeroX returns the bytes represented by the hexadecimal string src.
+// DecodeHexZeroX returns the bytes represented by the hexadecimal string src.
 //
-// DecodeZeroX expects that src contains only hex characters and must contain a `0x` prefix.
-// If the input is malformed, DecodeZeroX returns an error.
-func DecodeZeroX(in string) ([]byte, error) {
+// DecodeHexZeroX expects that src contains only hex characters and must contain a `0x` prefix.
+// If the input is malformed, DecodeHexZeroX returns an error.
+func DecodeHexZeroX(in string) ([]byte, error) {
 	if in == "" {
 		return nil, errors.Errorf("empty hex string")
 	}

--- a/internal/encoding/hex_test.go
+++ b/internal/encoding/hex_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_EncodeZeroX(t *testing.T) {
+func Test_EncodeHexZeroX(t *testing.T) {
 	assert := assert.New(t)
 	type args struct {
 		in []byte
@@ -41,7 +41,7 @@ func Test_EncodeZeroX(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotEncoded := EncodeZeroX(tt.args.in)
+			gotEncoded := EncodeHexZeroX(tt.args.in)
 			if !assert.Equal(tt.wantEncoded, gotEncoded) {
 				t.Errorf("EncodeZeroX() gotEncoded = %v, want %v", gotEncoded, tt.wantEncoded)
 			}
@@ -49,7 +49,7 @@ func Test_EncodeZeroX(t *testing.T) {
 	}
 }
 
-func Test_DecodeZeroX(t *testing.T) {
+func Test_DecodeHexZeroX(t *testing.T) {
 	type args struct {
 		in string
 	}
@@ -86,7 +86,7 @@ func Test_DecodeZeroX(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := DecodeZeroX(tt.args.in)
+			got, err := DecodeHexZeroX(tt.args.in)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("decodeZeroX() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/pubkey/encode.go
+++ b/internal/pubkey/encode.go
@@ -25,10 +25,10 @@ func EncodeByProtocol(in []byte, protocol string) (encoded, encodingType string,
 	switch protocol {
 	case protocols.Ethereum:
 		encodingType = encoding.TypeHex0XPrefix
-		encoded = encoding.EncodeZeroX(in)
+		encoded = encoding.EncodeHexZeroX(in)
 	case protocols.Substrate:
 		encodingType = encoding.TypeHex0XPrefix
-		encoded = encoding.EncodeZeroX(in)
+		encoded = encoding.EncodeHexZeroX(in)
 	default:
 		err = errors.Errorf("%q unsupported protocol", protocol)
 	}


### PR DESCRIPTION
- [x]  update docs for EncodeHexZeroX

- [x] rename DecodeZeroX to DecodeHexZeroX
- [x] update docs for DecodeHexZeroX
- [x] rename tests

fixes #429 