### PR TITLE
chore: add contructor for ethereum txOptions

### DIFF
--- a/cmd/indexer/internal/ethereum/transaction.go
+++ b/cmd/indexer/internal/ethereum/transaction.go
@@ -25,6 +25,12 @@ type txOptions struct {
 	block *types.Block
 }
 
+func NewTxOptions(block *types.Block) actions.TransactionOptions {
+	return &txOptions{
+		block: block,
+	}
+}
+
 func NewTransactionProcessor(store datastore.TransactionStore, rawStore datastore.RawTransactionStore, pkStore datastore.PublicKeyStore, networkID *big.Int) *Transaction {
 	return &Transaction{
 		txStore:    store,


### PR DESCRIPTION
Hi @robdefeo, I've looked at the [txOptions](https://github.com/mailchain/mailchain/blob/master/cmd/indexer/internal/ethereum/transaction.go#L24), since the type [assertion](https://github.com/mailchain/mailchain/blob/master/cmd/indexer/internal/ethereum/transaction.go#L44) is needed to get the block [info](https://github.com/mailchain/mailchain/blob/master/cmd/indexer/internal/ethereum/transaction.go#L49-L75) to be able to store the pub key and there is no way to create the `txOptions struct` from outside the package I've added a constructor that should solve this.

Let me know what you think.