### PR TITLE
chore: remove go 1.12 from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ services:
 go_import_path: github.com/mailchain/mailchain
 matrix:
   include:
-    - go: 1.12.x
-      env: 
-      - GO111MODULE=on
     - go: 1.13.x
       env: 
       - DEPLOY=true


### PR DESCRIPTION
closes #586 