### PR TITLE
fix: handle server side error for blockscout

### DIFF
--- a/internal/clients/blockscout/api.go
+++ b/internal/clients/blockscout/api.go
@@ -75,7 +75,7 @@ func (c APIClient) getTransactionsByAddress(network string, address []byte) (*tx
 	}
 
 	if txListResponse.StatusCode() >= 500 {
-		return nil, errors.Errorf("Received server side error from URL: %s. statusCode %s, body:%s", config.url, txListResponse.StatusCode(), string(txListResponse.Body()))
+		return nil, errors.Errorf("Received server side error from URL: %s. statusCode %d, body:%s", config.url, txListResponse.StatusCode(), string(txListResponse.Body()))
 	}
 
 	txResult := &txList{}

--- a/internal/clients/blockscout/api.go
+++ b/internal/clients/blockscout/api.go
@@ -74,6 +74,10 @@ func (c APIClient) getTransactionsByAddress(network string, address []byte) (*tx
 		return nil, errors.WithStack(err)
 	}
 
+	if txListResponse.StatusCode() >= 500 {
+		return nil, errors.Errorf("Received server side error from URL: %s. statusCode %s, body:%s", config.url, txListResponse.StatusCode(), string(txListResponse.Body()))
+	}
+
 	txResult := &txList{}
 	if err := json.Unmarshal(txListResponse.Body(), txResult); err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
Handle 5xx codes with an error to upper layer for blockscout