### PR TITLE
feat: speed up getting messages

### DIFF
--- a/cmd/mailchain/http/handlers/messages.go
+++ b/cmd/mailchain/http/handlers/messages.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/mailchain/mailchain/cmd/internal/http/params"
+	"github.com/mailchain/mailchain/crypto/cipher"
 	"github.com/mailchain/mailchain/encoding"
 	"github.com/mailchain/mailchain/errs"
 	"github.com/mailchain/mailchain/internal/addressing"
@@ -72,7 +73,12 @@ func GetMessages(receivers map[string]mailbox.Receiver, inbox stores.State, cach
 			return
 		}
 
+<<<<<<< Updated upstream
 		messages := make([]getMessage, len(txs))
+=======
+		decrypters := map[byte]cipher.Decrypter{}
+		messages := make([]getMessage, 0, len(txs))
+>>>>>>> Stashed changes
 
 		for i, tx := range txs {
 			buf := make([]byte, binary.MaxVarintLen64)
@@ -94,14 +100,14 @@ func GetMessages(receivers map[string]mailbox.Receiver, inbox stores.State, cach
 				continue
 			}
 
-			decrypter, err := ks.GetDecrypter(req.addressBytes, req.Protocol, req.Network, decrypterKind, deriveKeyOptions)
+			decrypter, err := getDecrypter(decrypters, decrypterKind, ks, req.addressBytes, req.Protocol, req.Network, deriveKeyOptions)
 			if err != nil {
 				messages[i] = getMessage{Status: errors.WithMessage(err, "could not get `decrypter`").Error(), BlockID: blockID, BlockIDEncoding: blockIDEncoding}
 
 				continue
 			}
 
-			message, err := mailbox.ReadMessage(tx.EnvelopeData, decrypter, cache)
+			message, err := mailbox.ReadMessage(tx.EnvelopeData, decrypter[decrypterKind], cache)
 			if err != nil {
 				messages[i] = getMessage{Status: errors.WithMessage(err, "could not read message").Error(), BlockID: blockID, BlockIDEncoding: blockIDEncoding}
 
@@ -143,6 +149,22 @@ func GetMessages(receivers map[string]mailbox.Receiver, inbox stores.State, cach
 
 		w.Header().Set("Content-Type", "application/json")
 	}
+}
+
+// getting a decrypted from key store can take ~800ms, this reduces the number of times it's fetched
+func getDecrypter(decrypters map[byte]cipher.Decrypter, kind byte, ks keystore.Store, address []byte, protocol, network string, deriveKeyOptions multi.OptionsBuilders) (map[byte]cipher.Decrypter, error) {
+	if _, ok := decrypters[kind]; ok {
+		return decrypters, nil
+	}
+
+	decrypter, err := ks.GetDecrypter(address, protocol, network, kind, deriveKeyOptions)
+	if err != nil {
+		return nil, errors.WithMessage(err, "could not get `decrypter`")
+	}
+
+	decrypters[kind] = decrypter
+
+	return decrypters, nil
 }
 
 func fetchMessages(ctx context.Context, protocol, network string, address []byte, receivers map[string]mailbox.Receiver, inbox stores.State) error {

--- a/cmd/mailchain/http/handlers/messages.go
+++ b/cmd/mailchain/http/handlers/messages.go
@@ -73,12 +73,8 @@ func GetMessages(receivers map[string]mailbox.Receiver, inbox stores.State, cach
 			return
 		}
 
-<<<<<<< Updated upstream
-		messages := make([]getMessage, len(txs))
-=======
 		decrypters := map[byte]cipher.Decrypter{}
 		messages := make([]getMessage, 0, len(txs))
->>>>>>> Stashed changes
 
 		for i, tx := range txs {
 			buf := make([]byte, binary.MaxVarintLen64)

--- a/cmd/mailchain/http/handlers/messages.go
+++ b/cmd/mailchain/http/handlers/messages.go
@@ -74,7 +74,7 @@ func GetMessages(receivers map[string]mailbox.Receiver, inbox stores.State, cach
 		}
 
 		decrypters := map[byte]cipher.Decrypter{}
-		messages := make([]getMessage, 0, len(txs))
+		messages := make([]getMessage, len(txs))
 
 		for i, tx := range txs {
 			buf := make([]byte, binary.MaxVarintLen64)

--- a/cmd/mailchain/http/handlers/messages_test.go
+++ b/cmd/mailchain/http/handlers/messages_test.go
@@ -112,7 +112,7 @@ func Test_GetMessages(t *testing.T) {
 
 					store := keystoretest.NewMockStore(mockCtrl)
 					store.EXPECT().HasAddress(addressingtest.EthereumCharlotte, "ethereum", "mainnet").Return(true).Times(1)
-					store.EXPECT().GetDecrypter(addressingtest.EthereumCharlotte, "ethereum", "mainnet", byte(0x73), multi.OptionsBuilders{}).Return(decrypter, nil)
+					store.EXPECT().GetDecrypter(addressingtest.EthereumCharlotte, "ethereum", "mainnet", byte(0x73), multi.OptionsBuilders{}).Return(decrypter, nil).Times(1)
 					return store
 				}(),
 			},
@@ -152,7 +152,7 @@ func Test_GetMessages(t *testing.T) {
 
 					store := keystoretest.NewMockStore(mockCtrl)
 					store.EXPECT().HasAddress(addressingtest.EthereumCharlotte, "ethereum", "mainnet").Return(true).Times(1)
-					store.EXPECT().GetDecrypter(addressingtest.EthereumCharlotte, "ethereum", "mainnet", byte(0x73), multi.OptionsBuilders{}).Return(decrypter, nil)
+					store.EXPECT().GetDecrypter(addressingtest.EthereumCharlotte, "ethereum", "mainnet", byte(0x73), multi.OptionsBuilders{}).Return(decrypter, nil).Times(1)
 					return store
 				}(),
 			},
@@ -193,7 +193,7 @@ func Test_GetMessages(t *testing.T) {
 
 					store := keystoretest.NewMockStore(mockCtrl)
 					store.EXPECT().HasAddress(addressingtest.EthereumCharlotte, "ethereum", "mainnet").Return(true).Times(1)
-					store.EXPECT().GetDecrypter(addressingtest.EthereumCharlotte, "ethereum", "mainnet", byte(0x73), multi.OptionsBuilders{}).Return(decrypter, nil)
+					store.EXPECT().GetDecrypter(addressingtest.EthereumCharlotte, "ethereum", "mainnet", byte(0x73), multi.OptionsBuilders{}).Return(decrypter, nil).Times(1)
 					return store
 				}(),
 				receivers: map[string]mailbox.Receiver{


### PR DESCRIPTION
Deriving keys with scrypt takes a long time ~800ms. This is being done for each messages. The only difference is the `decryptedKind` which is often the same. Used a map to reduce the number of times this happens.