### PR TITLE
fix: work round build not parsing all dates

### DIFF
--- a/internal/mail/rfc2822/date.go
+++ b/internal/mail/rfc2822/date.go
@@ -1,0 +1,163 @@
+package rfc2822
+
+import (
+	"mime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// mailParseDate parses an RFC 5322 date string. Its a copy from /usr/local/go/src/net/mail/message.go
+// unexplained issue where some dates were not being parsed by the built binary.
+// Current thought is it's related to the build container. Re-vist this when that changes or is updated.
+func mailParseDate(date string) (time.Time, error) {
+	dateLayoutsBuildOnce.Do(buildDateLayouts)
+	// CR and LF must match and are tolerated anywhere in the date field.
+	date = strings.ReplaceAll(date, "\r\n", "")
+	if strings.Index(date, "\r") != -1 {
+		return time.Time{}, errors.New("mail: header has a CR without LF")
+	}
+	// Re-using some addrParser methods which support obsolete text, i.e. non-printable ASCII
+	p := addrParser{date, nil}
+	p.skipSpace()
+
+	// RFC 5322: zone = (FWS ( "+" / "-" ) 4DIGIT) / obs-zone
+	// zone length is always 5 chars unless obsolete (obs-zone)
+	if ind := strings.IndexAny(p.s, "+-"); ind != -1 && len(p.s) >= ind+5 {
+		date = p.s[:ind+5]
+		p.s = p.s[ind+5:]
+	} else {
+		ind := strings.Index(p.s, "T")
+		if ind == 0 {
+			// In this case we have the following date formats:
+			// * Thu, 20 Nov 1997 09:55:06 MDT
+			// * Thu, 20 Nov 1997 09:55:06 MDT (MDT)
+			// * Thu, 20 Nov 1997 09:55:06 MDT (This comment)
+			ind = strings.Index(p.s[1:], "T")
+			if ind != -1 {
+				ind++
+			}
+		}
+
+		if ind != -1 && len(p.s) >= ind+5 {
+			// The last letter T of the obsolete time zone is checked when no standard time zone is found.
+			// If T is misplaced, the date to parse is garbage.
+			date = p.s[:ind+1]
+			p.s = p.s[ind+1:]
+		}
+	}
+	if !p.skipCFWS() {
+		return time.Time{}, errors.New("mail: misformatted parenthetical comment")
+	}
+	for _, layout := range dateLayouts {
+		t, err := time.Parse(layout, date)
+		if err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, errors.New("mail: header could not be parsed")
+}
+
+type addrParser struct {
+	s   string
+	dec *mime.WordDecoder // may be nil
+}
+
+// skipCFWS skips CFWS as defined in RFC5322.
+func (p *addrParser) skipCFWS() bool {
+	p.skipSpace()
+
+	for {
+		if !p.consume('(') {
+			break
+		}
+
+		if _, ok := p.consumeComment(); !ok {
+			return false
+		}
+
+		p.skipSpace()
+	}
+
+	return true
+}
+
+// skipSpace skips the leading space and tab characters.
+func (p *addrParser) skipSpace() {
+	p.s = strings.TrimLeft(p.s, " \t")
+}
+func (p *addrParser) consume(c byte) bool {
+	if p.empty() || p.peek() != c {
+		return false
+	}
+	p.s = p.s[1:]
+	return true
+}
+func (p *addrParser) consumeComment() (string, bool) {
+	// '(' already consumed.
+	depth := 1
+
+	var comment string
+	for {
+		if p.empty() || depth == 0 {
+			break
+		}
+
+		if p.peek() == '\\' && p.len() > 1 {
+			p.s = p.s[1:]
+		} else if p.peek() == '(' {
+			depth++
+		} else if p.peek() == ')' {
+			depth--
+		}
+		if depth > 0 {
+			comment += p.s[:1]
+		}
+		p.s = p.s[1:]
+	}
+
+	return comment, depth == 0
+}
+
+func (p *addrParser) peek() byte {
+	return p.s[0]
+}
+
+func (p *addrParser) empty() bool {
+	return p.len() == 0
+}
+
+func (p *addrParser) len() int {
+	return len(p.s)
+}
+
+var (
+	dateLayoutsBuildOnce sync.Once
+	dateLayouts          []string
+)
+
+func buildDateLayouts() {
+	// Generate layouts based on RFC 5322, section 3.3.
+
+	dows := [...]string{"", "Mon, "}   // day-of-week
+	days := [...]string{"2", "02"}     // day = 1*2DIGIT
+	years := [...]string{"2006", "06"} // year = 4*DIGIT / 2*DIGIT
+	seconds := [...]string{":05", ""}  // second
+	// "-0700 (MST)" is not in RFC 5322, but is common.
+	zones := [...]string{"-0700", "MST"} // zone = (("+" / "-") 4DIGIT) / "GMT" / ...
+
+	for _, dow := range dows {
+		for _, day := range days {
+			for _, year := range years {
+				for _, second := range seconds {
+					for _, zone := range zones {
+						s := dow + day + " Jan " + year + " 15:04" + second + " " + zone
+						dateLayouts = append(dateLayouts, s)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/mail/rfc2822/date_test.go
+++ b/internal/mail/rfc2822/date_test.go
@@ -1,0 +1,239 @@
+package rfc2822
+
+import (
+	"net/mail"
+	"testing"
+	"time"
+)
+
+func TestDateParsing(t *testing.T) {
+	tests := []struct {
+		dateStr string
+		exp     time.Time
+	}{
+		// RFC 5322, Appendix A.1.1
+		{
+			"Fri, 21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+		},
+		// RFC 5322, Appendix A.6.2
+		// Obsolete date.
+		{
+			"21 Nov 97 09:55:06 GMT",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("GMT", 0)),
+		},
+		// Commonly found format not specified by RFC 5322.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -0600 (MDT)",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+		},
+		{
+			"Thu, 20 Nov 1997 09:55:06 -0600 (MDT)",
+			time.Date(1997, 11, 20, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+		},
+		{
+			"Thu, 20 Nov 1997 09:55:06 GMT (GMT)",
+			time.Date(1997, 11, 20, 9, 55, 6, 0, time.UTC),
+		},
+		{
+			"Fri, 21 Nov 1997 09:55:06 +1300 (TOT)",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", +13*60*60)),
+		},
+	}
+	for _, test := range tests {
+		hdr := mail.Header{
+			"Date": []string{test.dateStr},
+		}
+		date, err := hdr.Date()
+		if err != nil {
+			t.Errorf("Header(Date: %s).Date(): %v", test.dateStr, err)
+		} else if !date.Equal(test.exp) {
+			t.Errorf("Header(Date: %s).Date() = %+v, want %+v", test.dateStr, date, test.exp)
+		}
+
+		date, err = mailParseDate(test.dateStr)
+		if err != nil {
+			t.Errorf("mailParseDate(%s): %v", test.dateStr, err)
+		} else if !date.Equal(test.exp) {
+			t.Errorf("mailParseDate(%s) = %+v, want %+v", test.dateStr, date, test.exp)
+		}
+	}
+}
+
+func TestDateParsingCFWS(t *testing.T) {
+	tests := []struct {
+		dateStr string
+		exp     time.Time
+		valid   bool
+	}{
+		// FWS-only. No date.
+		{
+			"   ",
+			// nil is not allowed
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// FWS is allowed before optional day of week.
+		{
+			"   Fri, 21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		{
+			"21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		{
+			"Fri 21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false, // missing ,
+		},
+		// FWS is allowed before day of month but HTAB fails.
+		{
+			"Fri,        21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// FWS is allowed before and after year but HTAB fails.
+		{
+			"Fri, 21 Nov       1997     09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// FWS is allowed before zone but HTAB is not handled. Obsolete timezone is handled.
+		{
+			"Fri, 21 Nov 1997 09:55:06           CST",
+			time.Time{},
+			true,
+		},
+		// FWS is allowed after date and a CRLF is already replaced.
+		{
+			"Fri, 21 Nov 1997 09:55:06           CST (no leading FWS and a trailing CRLF) \r\n",
+			time.Time{},
+			true,
+		},
+		// CFWS is a reduced set of US-ASCII where space and accentuated are obsolete. No error.
+		{
+			"Fri, 21    Nov 1997    09:55:06 -0600 (MDT and non-US-ASCII signs éèç )",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// CFWS is allowed after zone including a nested comment.
+		// Trailing FWS is allowed.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// CRLF is incomplete and misplaced.
+		{
+			"Fri, 21 Nov 1997 \r 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// CRLF is complete but misplaced. No error is returned.
+		{
+			"Fri, 21 Nov 199\r\n7  09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true, // should be false in the strict interpretation of RFC 5322.
+		},
+		// Invalid ASCII in date.
+		{
+			"Fri, 21 Nov 1997 ù 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// CFWS chars () in date.
+		{
+			"Fri, 21 Nov () 1997 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// Timezone is invalid but T is found in comment.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -060    \r\n (Thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// Date has no month.
+		{
+			"Fri, 21  1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// Invalid month : OCT iso Oct
+		{
+			"Fri, 21 OCT 1997 09:55:06 CST",
+			time.Time{},
+			false,
+		},
+		// A too short time zone.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -060",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// A too short obsolete time zone.
+		{
+			"Fri, 21  1997 09:55:06 GT",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// Ensure that the presence of "T" in the date
+		// doesn't trip out ParseDate, as per issue 39260.
+		{
+			"Tue, 26 May 2020 14:04:40 GMT",
+			time.Date(2020, 05, 26, 14, 04, 40, 0, time.UTC),
+			true,
+		},
+		{
+			"Tue, 26 May 2020 14:04:40 UT",
+			time.Date(2020, 05, 26, 14, 04, 40, 0, time.UTC),
+			false,
+		},
+		{
+			"Thu, 21 May 2020 14:04:40 UT",
+			time.Date(2020, 05, 21, 14, 04, 40, 0, time.UTC),
+			false,
+		},
+		{
+			"Thu, 21 May 2020 14:04:40 UTC",
+			time.Date(2020, 05, 21, 14, 04, 40, 0, time.UTC),
+			true,
+		},
+		{
+			"Fri, 21 Nov 1997 09:55:06 GMT (GMT)",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.UTC),
+			true,
+		},
+	}
+	for _, test := range tests {
+		hdr := mail.Header{
+			"Date": []string{test.dateStr},
+		}
+		date, err := hdr.Date()
+		if err != nil && test.valid {
+			t.Errorf("Header(Date: %s).Date(): %v", test.dateStr, err)
+		} else if err == nil && test.exp.IsZero() {
+			// OK.  Used when exact result depends on the
+			// system's local zoneinfo.
+		} else if err == nil && !date.Equal(test.exp) && test.valid {
+			t.Errorf("Header(Date: %s).Date() = %+v, want %+v", test.dateStr, date, test.exp)
+		} else if err == nil && !test.valid { // an invalid expression was tested
+			t.Errorf("Header(Date: %s).Date() did not return an error but %v", test.dateStr, date)
+		}
+
+		date, err = mailParseDate(test.dateStr)
+		if err != nil && test.valid {
+			t.Errorf("mailParseDate(%s): %v", test.dateStr, err)
+		} else if err == nil && test.exp.IsZero() {
+			// OK.  Used when exact result depends on the
+			// system's local zoneinfo.
+		} else if err == nil && !test.valid { // an invalid expression was tested
+			t.Errorf("mailParseDate(%s) did not return an error but %v", test.dateStr, date)
+		} else if err == nil && test.valid && !date.Equal(test.exp) {
+			t.Errorf("mailParseDate(%s) = %+v, want %+v", test.dateStr, date, test.exp)
+		}
+	}
+}

--- a/internal/mail/rfc2822/headers.go
+++ b/internal/mail/rfc2822/headers.go
@@ -31,14 +31,17 @@ func parseHeaders(h nm.Header) (*mail.Headers, error) {
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to parse `date`")
 	}
+
 	subject, err := parseSubject(h)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to parse `subject`")
 	}
+
 	to, err := parseTo(h)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to parse `to`")
 	}
+
 	from, err := parseFrom(h)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to parse `from`")
@@ -64,12 +67,14 @@ func parseTo(h nm.Header) (*mail.Address, error) {
 	if !ok {
 		return nil, errors.Errorf("header missing")
 	}
+
 	if len(sources) == 0 {
 		return nil, errors.Errorf("empty header")
 	}
 
 	return mail.ParseAddress(sources[0], "", "")
 }
+
 func parseFrom(h nm.Header) (*mail.Address, error) {
 	sources, ok := h["From"]
 	if !ok {
@@ -90,10 +95,12 @@ func parseDate(h nm.Header) (*time.Time, error) {
 	if len(dateStrings) == 0 {
 		return nil, errors.Errorf("empty header")
 	}
-	t, err := nm.ParseDate(dateStrings[0])
+
+	t, err := mailParseDate(strings.TrimSpace(dateStrings[0]))
 	if err != nil {
 		return nil, err
 	}
+
 	return &t, nil
 }
 


### PR DESCRIPTION
Work around to fix a strange issue not parse date in the build binary. Seemingly valid dates are not being parsed but only by the built binary. Likely a problem with the build container but this work around seems to work for now.